### PR TITLE
reorganized test_waldo to match the HOWTO

### DIFF
--- a/test_waldo.py
+++ b/test_waldo.py
@@ -19,7 +19,7 @@ class TestAE(unittest.TestCase):
         # Vacuous: No rows
         self.assertTrue(all_row_exists_waldo([]))
         # Vacuous: No columns
-        self.assertFalse(all_row_exists_waldo([[],[]]))
+        self.assertFalse(all_row_exists_waldo([[], []]))
 
     # By column
     def test_exists_waldo_every_col(self):
@@ -34,7 +34,8 @@ class TestAE(unittest.TestCase):
         # Vacuous: No rows
         self.assertTrue(all_col_exists_waldo([]))
         # Vacuous: No columns
-        self.assertTrue(all_col_exists_waldo([[],[]]))
+        self.assertTrue(all_col_exists_waldo([[], []]))
+
 
 class TestAA(unittest.TestCase):
     """For all x, for all y . P(y)"""
@@ -45,13 +46,12 @@ class TestAA(unittest.TestCase):
                                            [Waldo, Waldo, Waldo],
                                            [Waldo, Waldo, Waldo]]))
         self.assertFalse(all_row_all_waldo([[Waldo, Waldo, Waldo, Waldo],
-                                           [Waldo, Waldo, Other, Waldo],
-                                           [Waldo, Waldo, Waldo, Waldo]]))
+                                            [Waldo, Waldo, Other, Waldo],
+                                            [Waldo, Waldo, Waldo, Waldo]]))
         # Vacuous: No rows
         self.assertTrue(all_row_all_waldo([]))
         # Vacuous: No columns
         self.assertTrue(all_row_all_waldo([[], [], []]))
-
 
     # By col
     def test_all_col_all_waldo(self):
@@ -59,41 +59,12 @@ class TestAA(unittest.TestCase):
                                            [Waldo, Waldo, Waldo],
                                            [Waldo, Waldo, Waldo]]))
         self.assertFalse(all_col_all_waldo([[Waldo, Waldo, Waldo, Waldo],
-                                           [Waldo, Waldo, Other, Waldo],
-                                           [Waldo, Waldo, Waldo, Waldo]]))
+                                            [Waldo, Waldo, Other, Waldo],
+                                            [Waldo, Waldo, Waldo, Waldo]]))
         # Vacuous: No rows
         self.assertTrue(all_row_all_waldo([]))
         # Vacuous: No columns
         self.assertTrue(all_row_all_waldo([[], [], []]))
-
-class TestEE(unittest.TestCase):
-    """There exists x such that there exists y . P(y)"""
-
-    # By row
-    def test_exists_row_exists_waldo(self):
-        self.assertTrue(exists_row_exists_waldo([[Other, Other, Other],
-                                                 [Other, Other, Waldo],
-                                                 [Other, Other, Other]]))
-        self.assertFalse(exists_row_exists_waldo([[Other, Other],
-                                              [Other, Other]]))
-        # Vacuous: No rows
-        self.assertFalse(exists_row_exists_waldo([]))
-        # Vacuous: No columns
-        self.assertFalse(exists_row_exists_waldo([[], []]))
-
-    # By column
-    def test_exists_col_exists_waldo(self):
-        self.assertTrue(exists_col_exists_waldo([[Other, Other, Other],
-                                              [Other, Other, Waldo],
-                                              [Other, Other, Other]]))
-        self.assertFalse(exists_col_exists_waldo([[Other, Other],
-                                          [Other, Other]]))
-
-        # Vacuous: No rows
-        self.assertFalse(exists_col_exists_waldo([]))
-        # Vacuous: No columns
-        self.assertFalse(exists_col_exists_waldo([[], []]))
-
 
 
 class TestEA(unittest.TestCase):
@@ -101,7 +72,6 @@ class TestEA(unittest.TestCase):
 
     # By row
     def test_exists_row_all_waldo(self):
-
         self.assertTrue(exists_row_all_waldo([[Other, Waldo, Other],
                                               [Waldo, Waldo, Waldo],
                                               [Other, Other, Other]]))
@@ -110,9 +80,9 @@ class TestEA(unittest.TestCase):
                                                [Waldo, Other, Waldo],
                                                [Other, Waldo, Waldo]]))
 
-        #Vacuous: No rows
+        # Vacuous: No rows
         self.assertFalse(exists_row_all_waldo([]))
-        #Vacuous: No columns
+        # Vacuous: No columns
         self.assertTrue(exists_row_all_waldo([[], []]))
 
     # By column
@@ -131,10 +101,34 @@ class TestEA(unittest.TestCase):
         self.assertFalse(exists_col_all_waldo([[], []]))
 
 
+class TestEE(unittest.TestCase):
+    """There exists x such that there exists y . P(y)"""
+
+    # By row
+    def test_exists_row_exists_waldo(self):
+        self.assertTrue(exists_row_exists_waldo([[Other, Other, Other],
+                                                 [Other, Other, Waldo],
+                                                 [Other, Other, Other]]))
+        self.assertFalse(exists_row_exists_waldo([[Other, Other],
+                                                  [Other, Other]]))
+        # Vacuous: No rows
+        self.assertFalse(exists_row_exists_waldo([]))
+        # Vacuous: No columns
+        self.assertFalse(exists_row_exists_waldo([[], []]))
+
+    # By column
+    def test_exists_col_exists_waldo(self):
+        self.assertTrue(exists_col_exists_waldo([[Other, Other, Other],
+                                                 [Other, Other, Waldo],
+                                                 [Other, Other, Other]]))
+        self.assertFalse(exists_col_exists_waldo([[Other, Other],
+                                                  [Other, Other]]))
+
+        # Vacuous: No rows
+        self.assertFalse(exists_col_exists_waldo([]))
+        # Vacuous: No columns
+        self.assertFalse(exists_col_exists_waldo([[], []]))
+
 
 if __name__ == "__main__":
     unittest.main()
-
-
-
-


### PR DESCRIPTION
the last two test suites are swapped, since that's how the HOWTO describes them. this made debugging a bit annoying for me since it was out of my predicted order.

i also cleaned up various indenting/whitespace issues so that pycharm is no longer angry at it.