### PR TITLE
Adjustements to the test file to match the docs

### DIFF
--- a/test_waldo.py
+++ b/test_waldo.py
@@ -1,6 +1,7 @@
 """Universal and existential quantifiers """
 
 import unittest
+
 from waldo import *
 
 
@@ -8,7 +9,7 @@ class TestAE(unittest.TestCase):
     """For all x, there exists y . P(y)"""
 
     # By row
-    def test_exists_waldo_every_row(self):
+    def test_all_row_exists_waldo(self):
         """For all rows in matrix, there exists a Waldo in the row"""
         self.assertTrue(all_row_exists_waldo([[Other, Other, Waldo],
                                               [Waldo, Other, Other],
@@ -22,7 +23,7 @@ class TestAE(unittest.TestCase):
         self.assertFalse(all_row_exists_waldo([[],[]]))
 
     # By column
-    def test_exists_waldo_every_col(self):
+    def test_all_col_exists_waldo(self):
         """For all columns in the matrix, there exists a Waldo in the column"""
         self.assertTrue(all_col_exists_waldo([[Other, Waldo, Other],
                                               [Waldo, Other, Other],
@@ -32,9 +33,9 @@ class TestAE(unittest.TestCase):
                                                [Waldo, Other, Other]]))
 
         # Vacuous: No rows
-        self.assertTrue(all_col_exists_waldo([]))
+        self.assertFalse(all_col_exists_waldo([]))
         # Vacuous: No columns
-        self.assertTrue(all_col_exists_waldo([[],[]]))
+        self.assertFalse(all_col_exists_waldo([[],[]]))
 
 class TestAA(unittest.TestCase):
     """For all x, for all y . P(y)"""
@@ -134,7 +135,3 @@ class TestEA(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-
-
-

--- a/test_waldo.py
+++ b/test_waldo.py
@@ -33,9 +33,9 @@ class TestAE(unittest.TestCase):
                                                [Waldo, Other, Other]]))
 
         # Vacuous: No rows
-        self.assertFalse(all_col_exists_waldo([]))
+        self.assertTrue(all_col_exists_waldo([]))
         # Vacuous: No columns
-        self.assertFalse(all_col_exists_waldo([[],[]]))
+        self.assertTrue(all_col_exists_waldo([[],[]]))
 
 class TestAA(unittest.TestCase):
     """For all x, for all y . P(y)"""


### PR DESCRIPTION
- Fixed some test names to better match the functions being run by the tests. This enables easier debugging because the tests correspond to the functions being called.

- Two asserts were backwards, at least in my opinion. When testing for "for all columns in matrix, there exists a Waldo in the column", my inclination would be that an empty matrix, or a matrix with empty rows, would produce `False`, because the verbiage states "exists a Waldo", which is not true for an empty element.